### PR TITLE
Fix GitHub Pages workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,8 +21,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: 'npm'
       - run: npm install
       - run: npm run build
+      - uses: actions/configure-pages@v4
       - uses: actions/upload-pages-artifact@v2
         with:
           path: ./dist


### PR DESCRIPTION
## Summary
- cache npm modules in the deploy workflow
- configure pages before uploading the artifact

## Testing
- `npm run lint`
- `npm run build`
