### PR TITLE
Improve maze drawing on mobile

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,9 +2,9 @@ import Maze from './components/Maze'
 
 function App() {
   return (
-    <div className='container mx-auto p-8 text-center flex flex-col items-center gap-4'>
+    <div className='container mx-auto p-4 text-center flex flex-col items-center gap-4'>
       <h1 className='text-3xl font-bold'>Maze Playground</h1>
-      <Maze width={12} height={12} size={320} />
+      <Maze width={12} height={12} size={360} />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- crisp canvas rendering using device pixel ratio
- allow resuming drawing from visited paths without lifting pointer
- reduce page padding and enlarge maze

## Testing
- `npm run lint`
- `npm run build`
